### PR TITLE
Installation paths for actionlib messages

### DIFF
--- a/cmake/genmsg-extras.cmake.in
+++ b/cmake/genmsg-extras.cmake.in
@@ -58,7 +58,7 @@ macro(add_message_files)
   list(APPEND ${PROJECT_NAME}_MESSAGE_FILES_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/${ARG_DIRECTORY})
 
   if(NOT ARG_NOINSTALL)
-    install(FILES ${FILES_W_PATH} DESTINATION share/${PROJECT_NAME}/${ARG_DIRECTORY})
+    install(FILES ${FILES_W_PATH} DESTINATION share/${PROJECT_NAME}/${INSTALL_DIRECTORY})
   endif()
 endmacro()
 
@@ -87,7 +87,7 @@ macro(add_service_files)
   list(APPEND ${PROJECT_NAME}_SERVICE_FILES ${FILES_W_PATH})
 
   if(NOT ARG_NOINSTALL)
-    install(FILES ${FILES_W_PATH} DESTINATION share/${PROJECT_NAME}/${INSTALL_DIRECTORY})
+    install(FILES ${FILES_W_PATH} DESTINATION share/${PROJECT_NAME}/${ARG_DIRECTORY})
   endif()
 endmacro()
 

--- a/cmake/genmsg-extras.cmake.in
+++ b/cmake/genmsg-extras.cmake.in
@@ -44,7 +44,7 @@ macro(add_message_files)
     get_filename_component(INSTALL_DIRECTORY ${ARG_DIRECTORY} NAME)
   else()
     set(DIRECTORY_FULL_PATH ${CMAKE_CURRENT_SOURCE_DIR}/${ARG_DIRECTORY})
-    set(INSTALL_DIRECTOORY ${ARG_DIRECTORY})
+    set(INSTALL_DIRECTORY ${ARG_DIRECTORY})
   endif()
 
   #todo, hack: handle this elsewhere when fixing the install stuff

--- a/cmake/genmsg-extras.cmake.in
+++ b/cmake/genmsg-extras.cmake.in
@@ -41,8 +41,10 @@ macro(add_message_files)
 
   if(IS_FULL_PATH)
     set(DIRECTORY_FULL_PATH ${ARG_DIRECTORY})
+    get_filename_component(INSTALL_DIRECTORY ${ARG_DIRECTORY} NAME)
   else()
     set(DIRECTORY_FULL_PATH ${CMAKE_CURRENT_SOURCE_DIR}/${ARG_DIRECTORY})
+    set(INSTALL_DIRECTOORY ${ARG_DIRECTORY})
   endif()
 
   #todo, hack: handle this elsewhere when fixing the install stuff
@@ -85,7 +87,7 @@ macro(add_service_files)
   list(APPEND ${PROJECT_NAME}_SERVICE_FILES ${FILES_W_PATH})
 
   if(NOT ARG_NOINSTALL)
-    install(FILES ${FILES_W_PATH} DESTINATION share/${PROJECT_NAME}/${ARG_DIRECTORY})
+    install(FILES ${FILES_W_PATH} DESTINATION share/${PROJECT_NAME}/${INSTALL_DIRECTORY})
   endif()
 endmacro()
 


### PR DESCRIPTION
This currently mashes two full paths together for the installation location of a msg generated from an action - e.g. on linux:

```
/opt/ros/catkin/native/share/actionlib/home/snorri/tmp/catkin/native/actionlib/actions_gen/TestAction.msg
```

Of course, falls over on windows with two C:\'s.

Problem is because of add_message_files. It didn't do anything different to modify the install location when IS_FULL_PATH was true - this occurs for action generated messages, but not for regular messages.

The same logic could be applied in the add_service_files function also, but probably is only triggered in add_message_files at the moment because of actions.
