### PR TITLE
avoid invoking genmsg extras multiple time

### DIFF
--- a/cmake/genmsg-extras.cmake.em
+++ b/cmake/genmsg-extras.cmake.em
@@ -1,12 +1,12 @@
 # generated from genmsg/cmake/genmsg-extras.cmake.in
 
+# set destination for langs
+set(GENMSG_LANGS_DESTINATION "etc/ros/genmsg")
+
 if(_GENMSG_EXTRAS_INCLUDED_)
   return()
 endif()
-set(_GENMSG_EXTRAS_INCLUDED_ TRUE)
-
-# set destination for langs
-set(GENMSG_LANGS_DESTINATION "etc/ros/genmsg")
+set(_GENMSG_EXTRAS_INCLUDED_ TRUE PARENT_SCOPE)
 
 include(CMakeParseArguments)
 


### PR DESCRIPTION
I noticed that the code in genmsg-extras.cmake is invoked multiple times in the same catkin build. Maybe that's intentional to remain flexible, but seems like a waste of timeto me.

The current if() block at the top only prevents it from being invoked from the same subdirectory/scope. So this is just a small optimisation (could be premature optimisation).
