### PR TITLE
Better errors

### DIFF
--- a/cmake/genmsg-extras.cmake.em
+++ b/cmake/genmsg-extras.cmake.em
@@ -64,6 +64,10 @@ macro(add_message_files)
     message(FATAL_ERROR "add_message_files() directory not found: ${MESSAGE_DIR}")
   endif()
 
+  if(${PROJECT_NAME}_GENERATE_MESSAGES)
+    message(FATAL_ERROR "generate_messages() must be called after add_message_files()")
+  endif()
+
   # if FILES are not passed search message files in the given directory
   # note: ARGV is not variable, so it can not be passed to list(FIND) directly
   set(_argv ${ARGV})
@@ -107,6 +111,10 @@ macro(add_service_files)
 
   if(NOT IS_DIRECTORY ${SERVICE_DIR})
     message(FATAL_ERROR "add_service_files() directory not found: ${SERVICE_DIR}")
+  endif()
+
+  if(${PROJECT_NAME}_GENERATE_MESSAGES)
+    message(FATAL_ERROR "generate_messages() must be called after add_service_files()")
   endif()
 
   # if FILES are not passed search service files in the given directory

--- a/cmake/genmsg-extras.cmake.em
+++ b/cmake/genmsg-extras.cmake.em
@@ -136,6 +136,11 @@ endmacro()
 
 macro(generate_messages)
   cmake_parse_arguments(ARG "" "" "DEPENDENCIES;LANGS" ${ARGN})
+
+  if(${PROJECT_NAME}_GENERATE_MESSAGES)
+    message(FATAL_ERROR "generate_messages() must only be called once per project'")
+  endif()
+
   if(ARG_UNPARSED_ARGUMENTS)
     message(FATAL_ERROR "generate_messages() called with unused arguments: ${ARG_UNPARSED_ARGUMENTS}")
   endif()


### PR DESCRIPTION
For cases where users get the macros in the wrong order.

I assume it does not cause errors to call e.g. add_message_files twice.

The only problem case left is if the user forgets to call generate_messages(). I though about checking that in catkin_package(), but not sure whether that's a good idea.

I think the following could maybe be better: make the xyz_genfoo macros depend on a target xyz_generation_check, that is initialised with  message(FATAL_ERROR "generate_messages not called"). 

And in generate_messages(), the target is then overwritten by No-op. What do you think?
