### PR TITLE
Add an explanation to error on partial overlay

### DIFF
--- a/cmake/pkg-genmsg.cmake.em
+++ b/cmake/pkg-genmsg.cmake.em
@@ -94,6 +94,10 @@ _generate_module_@(l[3:])(@pkg_name
   "${ALL_GEN_OUTPUT_FILES_@(l[3:])}"
 )
 
+if(TARGET @(pkg_name)_generate_messages_@(l[3:]))
+  message( FATAL_ERROR "You are trying to overlay '@(pkg_name)' which was already (transitively) included by another module in the workspace. To successfully overlay a module you have to overlay all required dependent modules as well.")
+endif()
+
 add_custom_target(@(pkg_name)_generate_messages_@(l[3:])
   DEPENDS ${ALL_GEN_OUTPUT_FILES_@(l[3:])}
 )


### PR DESCRIPTION
I spent 4 hours searching for the bug and possible workarounds before I
figured this one out:

Fatal Error: target <MODULE>_generate_messages_cpp already defined in module
<SEEMINGLY_UNRELATED_MODULE>

We shouldn't really do anything here but error out, because it's a bad idea to
partially overlay the module in the new workspace - Everything in alphabet
before <MODULE> in the workspace which transitively relies on <MODULE> uses
the old one instead of the overlay..

But the old error message is pretty unhelpful and confusing.
