### PR TITLE
fix objects.inv urls

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -256,8 +256,8 @@ texinfo_documents = [
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
     'genmsg': ('http://ros.org/doc/api/genmsg/html', None),
-    'vcstools': ('http://ros.org/doc/api/vcstools/html', None),
-    'rosinstall': ('http://ros.org/doc/api/rosinstall/html', None),
-    'rospkg': ('http://ros.org/doc/api/rosinstall/html', None),
-    'rosdep2': ('http://ros.org/doc/api/rosdep2/html', None),
+    'vcstools': ('http://docs.ros.org/independent/api/vcstools/html', None),
+    'rosinstall': ('http://docs.ros.org/independent/api/rosinstall/html', None),
+    'rospkg': ('http://docs.ros.org/independent/api/rospkg/html', None),
+    'rosdep2': ('http://docs.ros.org/independent/api/rosdep/html', None),
     }


### PR DESCRIPTION
Fixes documentation warnings: http://build.ros.org/job/Jdoc__genmsg__ubuntu_trusty_amd64/9/
