### PR TITLE
find_package(catkin)

### DIFF
--- a/cmake/genmsg-extras.cmake.em
+++ b/cmake/genmsg-extras.cmake.em
@@ -8,6 +8,9 @@ set(_GENMSG_EXTRAS_INCLUDED_ TRUE)
 # set destination for langs
 set(GENMSG_LANGS_DESTINATION "etc/ros/genmsg")
 
+# We need various macros and variables that are provided by catkin
+find_package(catkin REQUIRED)
+
 @[if DEVELSPACE]@
 # bin dir variables in develspace
 set(GENMSG_CHECK_DEPS_SCRIPT "@(CMAKE_CURRENT_SOURCE_DIR)/scripts/genmsg_check_deps.py")

--- a/package.xml
+++ b/package.xml
@@ -17,6 +17,7 @@
   <author>Ken Conley</author>
 
   <buildtool_depend version_gte="0.5.74">catkin</buildtool_depend>
+  <run_depend>catkin</run_depend>
 
   <export>
     <rosdoc config="rosdoc.yaml"/>


### PR DESCRIPTION
If you have a directory with two files, `Foo.msg` and `CMakeLists.txt`, with the following content:

Foo.msg:

```
int16 foo
```

CMakeLists.txt:

```
cmake_minimum_required(VERSION 2.8.3)
#find_package(catkin REQUIRED)
find_package(genmsg REQUIRED)
add_message_files(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} FILES Foo.msg)
```

then running `cmake` yields this error about an undefined macro that's provided by catkin:

```
-- Using these message generators: 
CMake Error at /opt/ros/jade/share/genmsg/cmake/genmsg-extras.cmake:110 (assert_file_exists):
  Unknown CMake command "assert_file_exists".
Call Stack (most recent call first):
  CMakeLists.txt:4 (add_message_files)
```

The error can be avoided by uncommenting the `find_package(catkin REQUIRED)` line in the user's `CMakeLists.txt`, but that's not a good answer.

This PR pushes the `find_package(catkin REQUIRED)` call into genmsg, where the macro is being called. I'm not sure whether genmsg's `package.xml` dependencies should also be modified.
