### PR TITLE
remove the implicit dependency on catkin

### DIFF
--- a/cmake/genmsg-extras.cmake.em
+++ b/cmake/genmsg-extras.cmake.em
@@ -112,7 +112,9 @@ macro(add_message_files)
 
   list(APPEND ${PROJECT_NAME}_MESSAGE_FILES ${FILES_W_PATH})
   foreach(file ${FILES_W_PATH})
-    assert_file_exists(${file} "message file not found")
+    if(NOT EXISTS ${file})
+      message(FATAL_ERROR "Assertion failed:  message file '${file}' not found")
+    endif()
   endforeach()
 
   # remember path to messages to resolve them as dependencies
@@ -169,7 +171,9 @@ macro(add_service_files)
 
   list(APPEND ${PROJECT_NAME}_SERVICE_FILES ${FILES_W_PATH})
   foreach(file ${FILES_W_PATH})
-    assert_file_exists(${file} "service file not found")
+    if(NOT EXISTS ${file})
+      message(FATAL_ERROR "Assertion failed:  service file '${file}' not found")
+    endif()
   endforeach()
 
   if(NOT ARG_NOINSTALL)


### PR DESCRIPTION
The function `assert_file_exists` is provided by `catkin` but the package doesn't run-depend on it (and probably shouldn't just for this trivial function).

Replaces #61.
