### PR TITLE
check target across package for existance

### DIFF
--- a/cmake/pkg-genmsg.cmake.em
+++ b/cmake/pkg-genmsg.cmake.em
@@ -158,7 +158,9 @@ if(@(l)_INSTALL_DIR AND EXISTS ${CATKIN_DEVEL_PREFIX}/${@(l)_INSTALL_DIR}/@pkg_n
   )
 endif()
 @[for d in dependencies]@
-add_dependencies(@(pkg_name)_generate_messages_@(l[3:]) @(d)_generate_messages_@(l[3:]))
+if(TARGET @(d)_generate_messages_@(l[3:]))
+  add_dependencies(@(pkg_name)_generate_messages_@(l[3:]) @(d)_generate_messages_@(l[3:]))
+endif()
 @[end for]@# dependencies
 @[end for]@# langs
 @[end if]@


### PR DESCRIPTION
When built in isolation targets from other packages are not available in the CMake context. Will fix CMake warnings in downstream packages.
