### PR TITLE
fix test: full_name is not optional

### DIFF
--- a/test/test_genmsg_msgs.py
+++ b/test/test_genmsg_msgs.py
@@ -191,7 +191,7 @@ def test_MsgSpec():
 
     # types and names mismatch
     try:
-        MsgSpec(['int32', 'int32'], ['intval'], [], 'int32 intval\int32 y')
+        MsgSpec(['int32', 'int32'], ['intval'], [], 'int32 intval\int32 y', 'x/Mismatch')
         assert False, "types and names must align"
     except: pass
 


### PR DESCRIPTION
When full_name is null, it will throw an error, but that's not what the test cares as the comment above read `# types and names mismatch`.