### PR TITLE
add architecture_independent flag

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -21,5 +21,6 @@
 
   <export>
     <rosdoc config="rosdoc.yaml"/>
+    <architecture_independent/>
   </export>
 </package>


### PR DESCRIPTION
@dirk-thomas Is it fair to assume that python only packages are architecture independent ?