### PR TITLE
use ast.literal_eval instead of eval

### DIFF
--- a/src/genmsg/msg_loader.py
+++ b/src/genmsg/msg_loader.py
@@ -39,6 +39,7 @@ values are the paths).  Compatible with ROS package system and other
 possible layouts.
 """
 
+import ast
 import os
 import sys
 
@@ -181,12 +182,7 @@ def convert_constant_value(field_type, val):
             raise InvalidMsgSpec("cannot coerce [%s] to %s (out of bounds)"%(val, field_type))
         return val
     elif field_type == 'bool':
-        if val in ('true', '1'):
-            return True
-        elif val in ('false', '0'):
-            return False
-        else:
-            raise InvalidMsgSpec("invalid value for bool type constant: [%s]"%val)
+        return ast.literal_eval(val)
     raise InvalidMsgSpec("invalid constant type: [%s]"%field_type)
 
 def _load_constant_line(orig_line):

--- a/src/genmsg/msg_loader.py
+++ b/src/genmsg/msg_loader.py
@@ -182,7 +182,7 @@ def convert_constant_value(field_type, val):
             raise InvalidMsgSpec("cannot coerce [%s] to %s (out of bounds)"%(val, field_type))
         return val
     elif field_type == 'bool':
-        return ast.literal_eval(val)
+        return True if ast.literal_eval(val) else False
     raise InvalidMsgSpec("invalid constant type: [%s]"%field_type)
 
 def _load_constant_line(orig_line):

--- a/src/genmsg/msg_loader.py
+++ b/src/genmsg/msg_loader.py
@@ -181,8 +181,12 @@ def convert_constant_value(field_type, val):
             raise InvalidMsgSpec("cannot coerce [%s] to %s (out of bounds)"%(val, field_type))
         return val
     elif field_type == 'bool':
-        # TODO: need to nail down constant spec for bool
-        return True if eval(val) else False
+        if val in ('true', '1'):
+            return True
+        elif val in ('false', '0'):
+            return False
+        else:
+            raise InvalidMsgSpec("invalid value for bool type constant: [%s]"%val)
     raise InvalidMsgSpec("invalid constant type: [%s]"%field_type)
 
 def _load_constant_line(orig_line):


### PR DESCRIPTION
This PR adds stricter syntax checking to bool constant value parsing.
Constant value for bool is rarely used in the wild (There are no usage in all released ROS packages named `-msgs` or `-srvs`).
But the current implementation allow to execute any Python code in the right side from `=` in bool constant lines with some tricks. I thinks this could be a potential security concern.

Bool constant syntax in this commit based on [ROS2 IDL] (http://design.ros2.org/articles/interface_definition.html).
This change introduce backward incompatibility since it  limits acceptable bool literal syntaxs significantly.
But as  I mentioned above, this syntax is rarely used and IMHO there is virtually no bad effect in real.
Considerable more moderate approach is to use `literal_eval()` function in Python's `ast` module.