### PR TITLE
Fix undefined name: ‘l’ —> “orig_line‘

### DIFF
--- a/src/genmsg/msg_loader.py
+++ b/src/genmsg/msg_loader.py
@@ -203,7 +203,7 @@ def _load_constant_line(orig_line):
     else:
         line_splits = [x.strip() for x in ' '.join(line_splits[1:]).split(CONSTCHAR)] #resplit on '='
         if len(line_splits) != 2:
-            raise InvalidMsgSpec("Invalid constant declaration: %s"%l)
+            raise InvalidMsgSpec("Invalid constant declaration: %s"%orig_line)
         name = line_splits[0]
         val = line_splits[1]
 


### PR DESCRIPTION
__l__ is an undefined name in this context.  In the error message we want to show the user the original line.

flake8 testing of https://github.com/ros/genmsg on Python 2.7.14

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./src/genmsg/msg_loader.py:206:69: F821 undefined name 'l'
            raise InvalidMsgSpec("Invalid constant declaration: %s"%l)
                                                                    ^
1     F821 undefined name 'l
```