### PR TITLE
Add buildtool depend on setuptools

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -21,6 +21,7 @@
   <author>Dirk Thomas</author>
 
   <buildtool_depend version_gte="0.5.74">catkin</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 2">python-setuptools</buildtool_depend>
   <buildtool_depend condition="$ROS_PYTHON_VERSION == 3">python3-setuptools</buildtool_depend>
   <exec_depend>catkin</exec_depend>
   <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-empy</exec_depend>

--- a/package.xml
+++ b/package.xml
@@ -21,6 +21,7 @@
   <author>Dirk Thomas</author>
 
   <buildtool_depend version_gte="0.5.74">catkin</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 3">python3-distutils</buildtool_depend>
   <exec_depend>catkin</exec_depend>
   <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-empy</exec_depend>
   <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-empy</exec_depend>

--- a/package.xml
+++ b/package.xml
@@ -21,7 +21,7 @@
   <author>Dirk Thomas</author>
 
   <buildtool_depend version_gte="0.5.74">catkin</buildtool_depend>
-  <buildtool_depend condition="$ROS_PYTHON_VERSION == 3">python3-distutils</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 3">python3-setuptools</buildtool_depend>
   <exec_depend>catkin</exec_depend>
   <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-empy</exec_depend>
   <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-empy</exec_depend>

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from distutils.core import setup
+from setuptools import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
 d = generate_distutils_setup(


### PR DESCRIPTION
Requires https://github.com/ros/rosdistro/pull/23532
See http://build.ros.org/job/Ndev__genmsg__ubuntu_focal_amd64/2/console

This seems to be python3 specific. I don't see a `python-distutils` package for python 2 in Debian or Ubuntu. It looks like every package importing `distutils` in its `setup.py` will need to depend on this. Maybe `catkin` should export the dependency instead?