### PR TITLE
Fixed comment handling in service spec string constants.

### DIFF
--- a/src/genmsg/msg_loader.py
+++ b/src/genmsg/msg_loader.py
@@ -460,7 +460,6 @@ def load_srv_from_string(msg_context, text, full_name):
     text_out = StringIO()
     accum = text_in
     for l in text.split('\n'):
-        l = l.split(COMMENTCHAR)[0].strip() #strip comments        
         if l.startswith(IODELIM): #lenient, by request
             accum = text_out
         else:

--- a/test/files/test_ros/srv/ServiceWithStringConstant.srv
+++ b/test/files/test_ros/srv/ServiceWithStringConstant.srv
@@ -1,0 +1,6 @@
+string EXAMPLE= here "#comments" are ignored, and leading and trailing whitespace removed
+int32 INTCONST=42  # Here comments should not be ignored
+string value
+---
+string RESULTEXAMPLE= here "#comments" are ignored too, and leading and trailing whitespace removed
+string return_value

--- a/test/test_genmsg_msg_loader.py
+++ b/test/test_genmsg_msg_loader.py
@@ -397,6 +397,41 @@ def test_load_srv_from_file():
     assert text == spec.text
     assert full_name == spec.full_name
 
+def test_load_srv_with_string_constant_from_file():
+    from genmsg.msg_loader import MsgContext, load_srv_from_file
+
+    msg_context = MsgContext.create_default()
+
+    d = get_test_dir()
+    filename = os.path.join(d, 'test_ros', 'srv', 'ServiceWithStringConstant.srv')
+    with open(filename, 'r') as f:
+        text = f.read()
+
+    full_name = 'test_ros/ServiceWithStringConstant'
+    spec = load_srv_from_file(msg_context, filename, full_name)
+    assert spec == load_srv_from_file(msg_context, filename, full_name)
+    assert ['string'] == spec.request.types, spec.request.types
+    assert ['value'] == spec.request.names
+    assert ['return_value'] == spec.response.names
+    assert len(spec.request.constants) == 2
+    index_string = 0 if spec.request.constants[0].name == 'EXAMPLE' else 1
+    index_int = 1 - index_string
+    constant = spec.request.constants[index_string]
+    assert constant.type == 'string'
+    assert constant.name == 'EXAMPLE'
+    assert constant.val == 'here "#comments" are ignored, and leading and trailing whitespace removed', '<{}>'.format(constant.val)
+    constant = spec.request.constants[index_int]
+    assert constant.type == 'int32'
+    assert constant.name == 'INTCONST'
+    assert constant.val == 42, '<{}>'.format(constant.val)
+    assert len(spec.response.constants) == 1
+    constant = spec.response.constants[0]
+    assert constant.type == 'string'
+    assert constant.name == 'RESULTEXAMPLE'
+    assert constant.val == 'here "#comments" are ignored too, and leading and trailing whitespace removed', '<{}>'.format(constant.val)
+    assert text == spec.text
+    assert full_name == spec.full_name
+
 def test_load_msg_depends():
     #TODO: should there just be a 'load_msg, implicit=True?'
     from genmsg.msg_loader import MsgContext, load_msg_by_type, load_msg_depends, MsgNotFound


### PR DESCRIPTION
This PR fixes #88.
I've simply removed the line that strips the comments since the `load_msg_from_string` function will handle them anyway. No need for code duplication.
Additionally, I've added a test that failed before the change and passes after it.