### PR TITLE
Properly escape path before using in regex

### DIFF
--- a/cmake/pkg-genmsg.cmake.em
+++ b/cmake/pkg-genmsg.cmake.em
@@ -149,11 +149,12 @@ if(@(l)_INSTALL_DIR AND EXISTS ${CATKIN_DEVEL_PREFIX}/${@(l)_INSTALL_DIR}/@pkg_n
     PATTERN "__init__.pyc" EXCLUDE
   )
   # install init files which are not in the root folder of the generated code
+  string(REGEX REPLACE "([][+.*()^])" "\\\\\\1" ESCAPED_PATH "${CATKIN_DEVEL_PREFIX}/${@(l)_INSTALL_DIR}/@(pkg_name)")
   install(
     DIRECTORY ${CATKIN_DEVEL_PREFIX}/${@(l)_INSTALL_DIR}/@pkg_name
     DESTINATION ${@(l)_INSTALL_DIR}
     FILES_MATCHING
-    REGEX "${CATKIN_DEVEL_PREFIX}/${@(l)_INSTALL_DIR}/@(pkg_name)/.+/__init__.pyc?$"
+    REGEX "${ESCAPED_PATH}/.+/__init__.pyc?$"
 @[end if]@
   )
 endif()


### PR DESCRIPTION
Currently, the pattern used to ensure `__init__.py`s are installed for package subdirectories (e.g. msg, srv) uses an un-escaped path. As a result, any special characters in any part of the path can throw off the regex and cause these files to not be properly installed.

Before using the path in the pattern, properly escape those special characters.